### PR TITLE
Here's the code change I've implemented:

### DIFF
--- a/game_screen.py
+++ b/game_screen.py
@@ -33,7 +33,7 @@ class GameScreen(Screen):
         self.blinking_buttons = []
         self.blinking_animations = []
 
-    def initialize_game(self, player_names, grid_size, game_turn_length):
+    def initialize_game(self, player_names, grid_size, game_turn_length, marker_percentage=0.1):
         self.main_layout.clear_widgets()
 
         # Initialize GameState
@@ -118,19 +118,25 @@ class GameScreen(Screen):
         # Initialize grid buttons
         self.grid_buttons = []
         total_cells = self.grid_size[0] * self.grid_size[1]
-        max_circles = int(total_cells * 0.1)  # 10% circles
-        placed_circles = 0
+        # Use the marker_percentage from StartScreen, default to 0.1 if not provided
+        max_circles = int(total_cells * marker_percentage)
+
+        # Create a list of all possible (row, col) coordinates
+        all_coordinates = []
+        for r in range(self.grid_size[1]):
+            for c in range(self.grid_size[0]):
+                all_coordinates.append((r, c))
+
+        # Randomly shuffle the list of all possible coordinates
+        random.shuffle(all_coordinates)
+
+        # Select the first `max_circles` coordinates for "O" markers
+        circle_coordinates = all_coordinates[:max_circles]
 
         for row in range(self.grid_size[1]):
             button_row = []
             for col in range(self.grid_size[0]):
-                if placed_circles < max_circles and random.random() < 0.3:
-                    cell_type = "Circle"
-                    placed_circles += 1
-                else:
-                    cell_type = ""
-
-                if cell_type == "Circle":
+                if (row, col) in circle_coordinates:
                     btn = Button(
                         text="O",
                         font_size=24,
@@ -149,9 +155,7 @@ class GameScreen(Screen):
                     )
                     btn.bind(on_press=self.on_grid_button_press)
                     btn.bind(on_release=self.show_company_info)
-
-                if cell_type != "Circle":
-                    btn.disabled = True  # Initially, all buttons are disabled
+                    btn.disabled = True  # Initially, all non-circle buttons are disabled
 
                 button_row.append(btn)
                 self.grid_layout.add_widget(btn)

--- a/start_screen.py
+++ b/start_screen.py
@@ -88,6 +88,35 @@ class StartScreen(Screen):
         grid_size_layout.add_widget(self.grid_size_spinner)
         layout.add_widget(grid_size_layout)
 
+        # Marker percentage selection
+        marker_percentage_layout = BoxLayout(size_hint=(1, None), height=50, spacing=10)
+        marker_percentage_label = Label(
+            text='Marker Percentage:',
+            size_hint=(0.3, 1),
+            font_size=24,
+            color=(1, 1, 1, 1),
+            font_name=FONT_PATH
+        )
+        self.marker_percentage_slider = Slider(
+            min=0,
+            max=50,
+            value=10,
+            step=1,
+            size_hint=(0.5, 1)
+        )
+        self.marker_percentage_value_label = Label(
+            text=f"{int(self.marker_percentage_slider.value)}%",
+            size_hint=(0.2, 1),
+            font_size=24,
+            color=(1, 1, 1, 1),
+            font_name=FONT_PATH
+        )
+        self.marker_percentage_slider.bind(value=self._update_marker_percentage_label)
+        marker_percentage_layout.add_widget(marker_percentage_label)
+        marker_percentage_layout.add_widget(self.marker_percentage_slider)
+        marker_percentage_layout.add_widget(self.marker_percentage_value_label)
+        layout.add_widget(marker_percentage_layout)
+
         # Game turn length input
         self.turn_length_input = TextInput(
             hint_text='Enter Game Turn Length (Default: 80)',
@@ -136,6 +165,9 @@ class StartScreen(Screen):
     def _update_button_round(self, instance, value):
         self.start_button_round.pos = instance.pos
         self.start_button_round.size = instance.size
+
+    def _update_marker_percentage_label(self, instance, value):
+        self.marker_percentage_value_label.text = f"{int(value)}%"
 
     def animate_widgets(self):
         # Fade in the title
@@ -194,6 +226,7 @@ class StartScreen(Screen):
 
         # Pass configuration to the game screen
         self.manager.current = 'game'
+        marker_percentage = self.marker_percentage_slider.value / 100.0
         self.manager.get_screen('game').initialize_game(
-            player_names, (cols, rows), game_turn_length
+            player_names, (cols, rows), game_turn_length, marker_percentage
         )

--- a/tests/test_game_setup.py
+++ b/tests/test_game_setup.py
@@ -1,0 +1,198 @@
+import unittest
+from unittest.mock import MagicMock, patch
+import os
+
+# Add project root to sys.path to allow importing project modules
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from kivy.uix.button import Button
+from kivy.uix.slider import Slider
+
+# Since Kivy properties are often initialized in a Kivy-specific way,
+# and we are not running a full Kivy app, we might need to mock parts of Kivy's infrastructure
+# or ensure that Kivy is initialized minimally if properties rely on that.
+# For this test, direct instantiation and attribute setting should work for non-graphical parts.
+
+from game_screen import GameScreen
+from start_screen import StartScreen
+from custom_widgets import ImageButton # Needed for GameScreen
+
+# Minimal Kivy App Mock to allow widget instantiation if needed
+class MinimalKivyAppMock:
+    def __init__(self):
+        self.root = None
+
+    def run(self):
+        pass
+
+@patch('kivy.core.window.Window', MagicMock()) # Mock Window
+@patch('kivy.uix.image.Image.source', MagicMock()) # Mock Image source loading
+@patch('kivy.uix.label.Label.font_name', MagicMock(return_value='Roboto')) # Mock font loading
+@patch('kivy.uix.textinput.TextInput', MagicMock()) # Mock TextInput
+@patch('kivy.uix.spinner.Spinner', MagicMock()) # Mock Spinner
+@patch('main.SpaceMonopolyApp') # Mock the main app if it's imported by screens
+class TestGameSetup(unittest.TestCase):
+
+    def setUp(self):
+        # Mock os.path.dirname and os.path.abspath for GameState if it uses them for path resolution
+        # This is important if GameState tries to load assets based on __file__
+        self.mock_os_path()
+
+        self.game_screen = GameScreen(name='game')
+        self.start_screen = StartScreen(name='start')
+
+        # Mock the screen manager for StartScreen
+        self.mock_screen_manager = MagicMock()
+        self.start_screen.manager = self.mock_screen_manager
+        self.mock_screen_manager.get_screen = MagicMock(return_value=self.game_screen)
+
+    def mock_os_path(self):
+        # Mock os.path.dirname and abspath to prevent issues with __file__ in GameState
+        # This ensures that asset paths are based on a predictable root, not the test file's location.
+        # In GameState, script_dir = os.path.dirname(os.path.abspath(__file__))
+        # We need to ensure this doesn't break when tests are run from a different directory.
+        # For this test, we can mock it to return a dummy path if asset loading isn't critical.
+        # If asset loading *is* critical, this mock would need to point to the actual asset directory.
+        self.patcher_dirname = patch('os.path.dirname', MagicMock(return_value='/fake/path'))
+        self.patcher_abspath = patch('os.path.abspath', MagicMock(return_value='/fake/path/game_logic.py'))
+        self.mock_dirname = self.patcher_dirname.start()
+        self.mock_abspath = self.patcher_abspath.start()
+
+    def tearDown(self):
+        self.patcher_dirname.stop()
+        self.patcher_abspath.stop()
+        # Clean up any Kivy specific global settings if necessary
+        pass
+
+    def test_o_marker_count(self):
+        grid_size = (10, 10)
+        marker_percentage = 0.20  # 20%
+        total_cells = grid_size[0] * grid_size[1]
+        expected_o_markers = int(total_cells * marker_percentage)
+
+        # Mock necessary parts of GameScreen that are UI-heavy or rely on Kivy app lifecycle
+        # We are primarily testing the logic within initialize_game, not the full UI rendering.
+        self.game_screen.game_state = MagicMock() # Mock GameState to avoid its internal logic
+        self.game_screen.grid_layout = MagicMock() # Mock GridLayout, we only care about buttons added
+        self.game_screen.grid_layout.add_widget = MagicMock() # Mock add_widget
+
+        # Call initialize_game
+        self.game_screen.initialize_game(
+            player_names=['Player 1', 'Player 2'],
+            grid_size=grid_size,
+            game_turn_length=80,
+            marker_percentage=marker_percentage
+        )
+
+        # Count 'O' markers
+        o_marker_count = 0
+        for row_buttons in self.game_screen.grid_buttons:
+            for button in row_buttons:
+                if isinstance(button, Button) and button.text == "O":
+                    o_marker_count += 1
+        
+        self.assertEqual(o_marker_count, expected_o_markers,
+                         f"Expected {expected_o_markers} 'O' markers, but found {o_marker_count}")
+
+    def test_o_marker_distribution(self):
+        grid_size = (20, 20) # Rows, Cols
+        marker_percentage = 0.10 # 10%
+        
+        self.game_screen.game_state = MagicMock()
+        self.game_screen.grid_layout = MagicMock()
+        self.game_screen.grid_layout.add_widget = MagicMock()
+
+        self.game_screen.initialize_game(
+            player_names=['P1', 'P2'],
+            grid_size=grid_size,
+            game_turn_length=80,
+            marker_percentage=marker_percentage
+        )
+
+        o_marker_coords = []
+        for r_idx, row_buttons in enumerate(self.game_screen.grid_buttons):
+            for c_idx, button in enumerate(row_buttons):
+                if isinstance(button, Button) and button.text == "O":
+                    o_marker_coords.append((r_idx, c_idx))
+
+        self.assertGreater(len(o_marker_coords), 0, "No 'O' markers found on the grid.")
+
+        rows, cols = grid_size
+        mid_row = rows // 2
+        mid_col = cols // 2
+
+        quadrants = {
+            "top_left": False, "top_right": False,
+            "bottom_left": False, "bottom_right": False
+        }
+
+        for r, c in o_marker_coords:
+            if r < mid_row and c < mid_col:
+                quadrants["top_left"] = True
+            elif r < mid_row and c >= mid_col:
+                quadrants["top_right"] = True
+            elif r >= mid_row and c < mid_col:
+                quadrants["bottom_left"] = True
+            elif r >= mid_row and c >= mid_col:
+                quadrants["bottom_right"] = True
+        
+        for quadrant, present in quadrants.items():
+            self.assertTrue(present, f"No 'O' markers found in the {quadrant} quadrant.")
+
+    def test_marker_percentage_passing_from_start_screen(self):
+        # Mock the initialize_game method on the GameScreen instance
+        self.game_screen.initialize_game = MagicMock()
+
+        # Set up StartScreen's UI elements that are accessed in start_game
+        self.start_screen.player_inputs = [MagicMock(text='P1'), MagicMock(text='P2')]
+        self.start_screen.grid_size_spinner = MagicMock(text='10x10')
+        self.start_screen.turn_length_input = MagicMock(text='50')
+        
+        # Create and set the marker_percentage_slider
+        self.start_screen.marker_percentage_slider = Slider(min=0, max=50, value=15)
+        # Ensure the label exists if _update_marker_percentage_label is called by slider value change
+        self.start_screen.marker_percentage_value_label = MagicMock()
+
+
+        # Call the start_game method
+        self.start_screen.start_game(None) # Argument is instance, can be None for this test
+
+        expected_marker_percentage = 0.15 # 15 / 100.0
+
+        # Assert that initialize_game was called with the correct marker_percentage
+        self.game_screen.initialize_game.assert_called_once()
+        args, kwargs = self.game_screen.initialize_game.call_args
+        
+        # The marker_percentage is passed as the 4th positional argument (index 3)
+        # or as a keyword argument. Let's check kwargs first, then args.
+        if 'marker_percentage' in kwargs:
+            passed_marker_percentage = kwargs['marker_percentage']
+        elif len(args) > 3: # player_names, grid_size, game_turn_length, marker_percentage
+            passed_marker_percentage = args[3]
+        else:
+            self.fail("marker_percentage not found in call to initialize_game")
+
+        self.assertAlmostEqual(passed_marker_percentage, expected_marker_percentage, places=2,
+                               msg="Marker percentage passed from StartScreen to GameScreen is incorrect.")
+        
+        # Also check other default parameters if necessary
+        self.assertEqual(args[0], ['P1', 'P2']) # player_names
+        self.assertEqual(args[1], (10,10))      # grid_size
+        self.assertEqual(args[2], 50)           # game_turn_length
+
+
+if __name__ == '__main__':
+    # Kivy setup might be needed if widgets directly interact with Window or App during init
+    # However, by mocking Window and specific widget properties, we can often avoid full Kivy app init.
+    # For these tests, we assume that the logic being tested in initialize_game and start_game
+    # doesn't deeply depend on a running Kivy application instance.
+    
+    # If Kivy complains about "No main window", you might need a minimal App setup:
+    # from kivy.app import App
+    # class TestApp(App):
+    #     def build(self):
+    #         return None # No root widget needed for these tests
+    # TestApp().run() # This line is problematic as it blocks. Better to mock Kivy internals.
+
+    unittest.main(argv=['first-arg-is-ignored'], exit=False)


### PR DESCRIPTION
feat: Implement random distribution of 'O' markers and user-configurable percentage

This addresses the issue of 'O' markers spawning only on the top half of the game board.

Changes include:

1.  **Randomized Marker Placement:** I modified `game_screen.py` to ensure 'O' markers are distributed randomly across the entire grid during board initialization. This is achieved by shuffling all possible grid coordinates and selecting a subset for marker placement.

2.  **User-Configurable Marker Percentage:** I added a slider to `start_screen.py` allowing you to define the percentage of 'O' markers on the game board (defaulting to 10%, with a range of 0-50%). This value is passed to `game_screen.py` and used to calculate the number of markers.

3.  **Unit Tests:** I added new tests in `tests/test_game_setup.py` to:
    - Verify that the correct number of 'O' markers are created based on the selected percentage.
    - Confirm that 'O' markers are distributed across different quadrants of the board, preventing clustering.
    - Ensure that the marker percentage selected on the start screen is correctly passed to and utilized by the game screen.

No changes were required in `main.py` as the data flow for the marker percentage is handled directly between `start_screen.py` and `game_screen.py`.