### PR TITLE
fix: Correct asset paths for images and fonts

### DIFF
--- a/game_logic.py
+++ b/game_logic.py
@@ -21,13 +21,13 @@ class GameState:
         # Company logos with absolute paths
         self.script_dir = script_dir
         self.company_logos = {
-            "Nerdniss": os.path.join(script_dir, 'nerdniss_logo.png'),
-            "Beetleguice": os.path.join(script_dir, 'beetleguice_logo.png'),
-            "StronCannon": os.path.join(script_dir, 'stroncannon_logo.png'),
-            "DebbiesKnees": os.path.join(script_dir, 'debbiesKnees_logo.png'),
-            "Pacifica": os.path.join(script_dir, 'pacifica_logo.png'),
+            "Nerdniss": os.path.join(script_dir, 'assets', 'images', 'nerdniss_logo.png'),
+            "Beetleguice": os.path.join(script_dir, 'assets', 'images', 'beetleguice_logo.png'),
+            "StronCannon": os.path.join(script_dir, 'assets', 'images', 'stroncannon_logo.png'),
+            "DebbiesKnees": os.path.join(script_dir, 'assets', 'images', 'debbiesKnees_logo.png'),
+            "Pacifica": os.path.join(script_dir, 'assets', 'images', 'pacifica_logo.png'),
         }
-        self.diamond_image_path = os.path.join(script_dir, 'diamond.png')
+        self.diamond_image_path = os.path.join(script_dir, 'assets', 'images', 'diamond.png')
 
         # Game data
         self.company_map = {}  # Maps coordinates to company info

--- a/start_screen.py
+++ b/start_screen.py
@@ -15,7 +15,7 @@ from kivy.properties import ObjectProperty
 from kivy.clock import Clock  # Import Clock for scheduling animations
 
 # Path to your custom font
-FONT_PATH = os.path.join(os.path.dirname(__file__), 'Orbitron-Regular.ttf')
+FONT_PATH = os.path.join(os.path.dirname(__file__), 'assets', 'fonts', 'Orbitron-Regular.ttf')
 
 
 class StartScreen(Screen):


### PR DESCRIPTION
This commit updates the codebase to use the correct paths for loading image and font assets, which are organized into `assets/images/` and `assets/fonts/` subdirectories.

Changes include:

- In `game_logic.py`:
    - Modified `GameState.__init__` to prepend `assets/images/` to filenames in `self.company_logos` and `self.diamond_image_path`. Paths are constructed using `os.path.join(script_dir, 'assets', 'images', filename)`.

- In `start_screen.py`:
    - Updated the `FONT_PATH` global variable to `os.path.join(os.path.dirname(__file__), 'assets', 'fonts', 'Orbitron-Regular.ttf')`.

These changes ensure that the application correctly locates all necessary visual and font assets, respecting the repository's directory structure.