### PR TITLE
I've made a fix: Import Slider widget in start_screen.py

### DIFF
--- a/start_screen.py
+++ b/start_screen.py
@@ -6,6 +6,7 @@ from kivy.uix.boxlayout import BoxLayout
 from kivy.uix.label import Label
 from kivy.uix.textinput import TextInput
 from kivy.uix.spinner import Spinner
+from kivy.uix.slider import Slider
 from kivy.uix.button import Button
 from kivy.uix.popup import Popup
 from kivy.graphics import Color, Rectangle, RoundedRectangle


### PR DESCRIPTION
This resolves a NameError that occurred because the Slider widget was used without being imported. I added `from kivy.uix.slider import Slider` to the import statements in `start_screen.py`.