### PR TITLE
Fix: Correct TypeError when placing diamond from UI

### DIFF
--- a/game_screen.py
+++ b/game_screen.py
@@ -279,7 +279,8 @@ class GameScreen(Screen):
         Place a diamond on the selected square and handle potential mergers.
         """
         current_coords = instance.coords
-        success, message = self.game_state.place_diamond(current_coords)
+        current_player_name = self.game_state.players[self.game_state.current_player_index]
+        success, message = self.game_state.place_diamond(current_coords, current_player_name)
         if success:
             if os.path.exists(self.game_state.diamond_image_path):
                 # Set the image source to diamond.png


### PR DESCRIPTION
The `place_diamond` method in `game_logic.py` was updated to accept a `current_player` argument as part of the bonus shares feature. However, the call site in `game_screen.py` was not updated to pass this new argument, resulting in a `TypeError` when you attempted to place a diamond through the UI.

This commit updates the `place_diamond` method in `game_screen.py` to correctly retrieve the current player's name from the game state and pass it when calling `self.game_state.place_diamond()`.

This resolves the `TypeError` and ensures that the bonus shares feature functions as intended when companies are formed by placing diamonds via the game interface.