### PR TITLE
Fix profile stats display and add extended stats

### DIFF
--- a/game_screen.py
+++ b/game_screen.py
@@ -257,6 +257,9 @@ class GameScreen(Screen):
         self.sidebar_visible = False
         self.sidebar_original_width_hint = 0.3
 
+        # Initialize game over flag
+        self.game_over_flag = False
+
         # Initialize properties for blinking
         self.blink_event = None
         self.blinking_buttons = []
@@ -265,6 +268,7 @@ class GameScreen(Screen):
     def initialize_game(self, player_configurations, grid_size, game_turn_length, marker_percentage=0.1): # player_names -> player_configurations
         self.main_layout.clear_widgets()
         self.o_marker_buttons = []
+        self.game_over_flag = False
 
         # Initialize ProfileManager and player profile objects
         self.profile_manager = ProfileManager()
@@ -1196,6 +1200,11 @@ class GameScreen(Screen):
         """
         Calculate final wealth and determine the winner.
         """
+        if self.game_over_flag:
+            return
+
+        self.game_over_flag = True
+
         player_wealth_summary = {
             player_name: self.game_state.player_wealth[player_name] for player_name in self.game_state.players
         }

--- a/start_screen.py
+++ b/start_screen.py
@@ -594,14 +594,20 @@ class StartScreen(Screen):
 
 
     def show_profile_management_popup(self, instance):
+        # Reload profiles to ensure we display the latest data
+        self.profile_manager.load_all_profiles()
+
         content_layout = BoxLayout(orientation='vertical', spacing=dp(10), padding=dp(10))
 
         # Header for the list
         header_layout = BoxLayout(orientation='horizontal', size_hint_y=None, height=dp(30), spacing=dp(5))
-        header_layout.add_widget(Label(text="Username", size_hint_x=0.3, font_name=FONT_PATH, font_size=dp(16)))
-        header_layout.add_widget(Label(text="High Score", size_hint_x=0.2, font_name=FONT_PATH, font_size=dp(16)))
-        header_layout.add_widget(Label(text="Games", size_hint_x=0.2, font_name=FONT_PATH, font_size=dp(16)))
-        header_layout.add_widget(Label(text="Actions", size_hint_x=0.3, font_name=FONT_PATH, font_size=dp(16)))
+        header_layout.add_widget(Label(text="Username", size_hint_x=0.2, font_name=FONT_PATH, font_size=dp(16)))
+        header_layout.add_widget(Label(text="HS", size_hint_x=0.15, font_name=FONT_PATH, font_size=dp(16)))
+        header_layout.add_widget(Label(text="G", size_hint_x=0.1, font_name=FONT_PATH, font_size=dp(16)))
+        header_layout.add_widget(Label(text="W", size_hint_x=0.1, font_name=FONT_PATH, font_size=dp(16)))
+        header_layout.add_widget(Label(text="L", size_hint_x=0.1, font_name=FONT_PATH, font_size=dp(16)))
+        header_layout.add_widget(Label(text="Avg", size_hint_x=0.15, font_name=FONT_PATH, font_size=dp(16)))
+        header_layout.add_widget(Label(text="Actions", size_hint_x=0.2, font_name=FONT_PATH, font_size=dp(16)))
         content_layout.add_widget(header_layout)
 
         scroll_view = ScrollView(size_hint=(1, 0.8))
@@ -634,14 +640,17 @@ class StartScreen(Screen):
             if profile_obj:
                 row_layout = BoxLayout(orientation='horizontal', spacing=dp(5), size_hint_y=None, height=dp(44))
 
-                row_layout.add_widget(Label(text=profile_obj.username, size_hint_x=0.3, font_name=FONT_PATH, font_size=dp(14)))
-                row_layout.add_widget(Label(text=str(profile_obj.high_score), size_hint_x=0.2, font_name=FONT_PATH, font_size=dp(14)))
-                row_layout.add_widget(Label(text=str(profile_obj.games_played), size_hint_x=0.2, font_name=FONT_PATH, font_size=dp(14)))
+                row_layout.add_widget(Label(text=profile_obj.username, size_hint_x=0.2, font_name=FONT_PATH, font_size=dp(14)))
+                row_layout.add_widget(Label(text=str(profile_obj.high_score), size_hint_x=0.15, font_name=FONT_PATH, font_size=dp(14)))
+                row_layout.add_widget(Label(text=str(profile_obj.games_played), size_hint_x=0.1, font_name=FONT_PATH, font_size=dp(14)))
+                row_layout.add_widget(Label(text=str(profile_obj.total_wins), size_hint_x=0.1, font_name=FONT_PATH, font_size=dp(14)))
+                row_layout.add_widget(Label(text=str(profile_obj.total_losses), size_hint_x=0.1, font_name=FONT_PATH, font_size=dp(14)))
+                row_layout.add_widget(Label(text=str(round(profile_obj.average_score)), size_hint_x=0.15, font_name=FONT_PATH, font_size=dp(14)))
 
-                actions_layout = BoxLayout(size_hint_x=0.3, spacing=dp(5))
-                rename_button = Button(text="Rename", font_size=dp(14), font_name=FONT_PATH)
+                actions_layout = BoxLayout(size_hint_x=0.2, spacing=dp(5))
+                rename_button = Button(text="Ren", font_size=dp(14), font_name=FONT_PATH)
                 rename_button.bind(on_press=partial(self._rename_profile_prompt, profile_obj.username))
-                delete_button = Button(text="Delete", font_size=dp(14), font_name=FONT_PATH)
+                delete_button = Button(text="Del", font_size=dp(14), font_name=FONT_PATH)
                 delete_button.bind(on_press=partial(self._delete_profile_confirm, profile_obj.username))
 
                 actions_layout.add_widget(rename_button)


### PR DESCRIPTION
This change addresses the issue where the "Manage Profile" screen would display stale data (e.g., 0 games played) even after games were completed, because the `ProfileManager` instance in `StartScreen` was not reloading data from disk.

It also enhances the profile list to display more detailed statistics as requested: Wins, Losses, and Average Score (rounded). The layout has been adjusted to fit these new columns.

---
*PR created automatically by Jules for task [5727540277873946240](https://jules.google.com/task/5727540277873946240) started by @TypeOfPrototype*